### PR TITLE
Add Trädportalen as a source

### DIFF
--- a/sources.js
+++ b/sources.js
@@ -463,6 +463,7 @@ module.exports = [
     ...require('./sources/france'),
     ...require('./sources/usa'),
     ...require('./sources/germany'),
+    ...require('./sources/sweden'),
 ];
 
     /*

--- a/sources/sweden.js
+++ b/sources/sweden.js
@@ -1,0 +1,19 @@
+module.exports = [
+  {
+    id: 'tradportalen',
+    info: 'https://www.tradportalen.se/Summary.aspx',
+    download: 'https://tradportalen.s3.eu-north-1.amazonaws.com/tradportalen.zip',
+    format: 'zip',
+    filename: 'data/combined.json',
+    short: 'Trädportalen',
+    long: 'Trädportalen',
+    country: 'Sweden',
+    crosswalk: {
+      scientific: x => String(x.Species).split(', ')[1],
+      common: x => String(x.Species).split(', ')[0],
+      height: 'Height',
+      dbh: x => Number(x['TrunkCircumference']) / 3.14159 * 2,
+    },
+    country: 'Sweden'
+  }
+]


### PR DESCRIPTION
I have uploaded all the observations from Trädportalen here: https://tradportalen.s3.eu-north-1.amazonaws.com/tradportalen.zip, it's one zipped file of GeoJSON (as you hinted, it does compress really well).

I have done my best to add it as a source here, but I more or less guessed from looking at some of the other sources, so I might have misunderstood some parts.

I tried to test this with `npm run get`, but it spiked my CPU at 100% for four full hours of CPU time now - not sure if that is normal or if I broke something.