### PR TITLE
Move Roosendaal from Belgium to Netherlands

### DIFF
--- a/sources/belgium.js
+++ b/sources/belgium.js
@@ -24,16 +24,6 @@ module.exports = [
         license: '',
     },
     {
-        id:'roosendaal_be',
-        short: 'Roosendaal',
-        long: 'Gemeente Roosendaal',
-        download: 'https://opendata.arcgis.com/datasets/f97b4a30ac914a73aa7552a96f0ae82d_0.zip',
-        info:'https://opendata.roosendaal.nl/datasets/gbi-boom-public',
-        crosswalk: {
-        },
-        license: '',
-    },
-    {
         id:'gent_be',
         short: 'Gent',
         long: 'Stad Gent',

--- a/sources/netherlands.js
+++ b/sources/netherlands.js
@@ -400,4 +400,14 @@ module.exports = [
         },
         license: '',
     },
+    {
+        id:'roosendaal_be',
+        short: 'Roosendaal',
+        long: 'Gemeente Roosendaal',
+        download: 'https://opendata.arcgis.com/datasets/f97b4a30ac914a73aa7552a96f0ae82d_0.zip',
+        info:'https://opendata.roosendaal.nl/datasets/gbi-boom-public',
+        crosswalk: {
+        },
+        license: '',
+    },
 ].map(x => ({ ...x, country: 'Netherlands' }));


### PR DESCRIPTION
Roosendaal is a city in the Netherlands, not in Belgium.